### PR TITLE
Update tooth.json

### DIFF
--- a/tooth.json
+++ b/tooth.json
@@ -17,7 +17,7 @@
                 {
                     "type": "tgz",
                     "urls": [
-                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{ version }}/bdsdown-darwin-amd64.tar.gz"
+                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{version}}/bdsdown-darwin-amd64.tar.gz"
                     ],
                     "placements": [
                         {
@@ -35,7 +35,7 @@
                 {
                     "type": "tgz",
                     "urls": [
-                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{ version }}/bdsdown-darwin-arm64.tar.gz"
+                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{version}}/bdsdown-darwin-arm64.tar.gz"
                     ],
                     "placements": [
                         {
@@ -53,7 +53,7 @@
                 {
                     "type": "tgz",
                     "urls": [
-                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{ version }}/bdsdown-linux-amd64.tar.gz"
+                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{version}}/bdsdown-linux-amd64.tar.gz"
                     ],
                     "placements": [
                         {
@@ -71,7 +71,7 @@
                 {
                     "type": "tgz",
                     "urls": [
-                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{ version }}/bdsdown-linux-arm64.tar.gz"
+                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{version}}/bdsdown-linux-arm64.tar.gz"
                     ],
                     "placements": [
                         {
@@ -89,7 +89,7 @@
                 {
                     "type": "zip",
                     "urls": [
-                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{ version }}/bdsdown-windows-amd64.zip"
+                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{version}}/bdsdown-windows-amd64.zip"
                     ],
                     "placements": [
                         {
@@ -107,7 +107,7 @@
                 {
                     "type": "zip",
                     "urls": [
-                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{ version }}/bdsdown-windows-arm64.zip"
+                        "https://github.com/LiteLDev/bdsdown/releases/download/v{{version}}/bdsdown-windows-arm64.zip"
                     ],
                     "placements": [
                         {


### PR DESCRIPTION
.Fix [space]version[space] in releases urls. [space] character caused by bdsdown lip pull failure .修复releases urls中的 [space]version[space] .[space]字符导致的bdsdown lip拉取失败的问题 ;P

## What does this PR do?



## Which issues does this PR resolve?



## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] Your code follows [Google Go Style Guide](https://google.github.io/styleguide/go/)
- [ ] You have tested all functions
- [ ] You have not used code without license
- [ ] You have added statement for third-party code
